### PR TITLE
Added Japanese localized terms to the manifest.json

### DIFF
--- a/related-records-autocalc-package/manifest.json
+++ b/related-records-autocalc-package/manifest.json
@@ -3,13 +3,16 @@
     "version": 1,
     "type": "APP",
     "name": {
+        "ja":"関連レコード一覧の値計算プラグイン",
         "en": "Related Records Value Calculations"
     },
     "description": {
+        "ja": "関連レコード一覧の値を計算し、指定のフィールドに結果を表示できます。（合計、平均、個数計算など）",
         "en": "Outputs a calculation of related records values (sum, average, count, etc)"
     },
     "icon": "image/icon.png",
     "homepage_url": {
+        "ja":"https://kintone.cybozu.co.jp/jp/",
         "en": "https://www.kintone.com"
     },
     "desktop": {


### PR DESCRIPTION
- Added the name and description of the plugin in Japanese and the Japanese Kintone website's URL to the manifest.json
- Now it shows its name and description in Japanese and the URL to the Japanese Kintone website when users set their language Japanese.